### PR TITLE
corner case for legacy configured content

### DIFF
--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ImageImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/ImageImpl.java
@@ -112,7 +112,7 @@ public class ImageImpl extends AbstractEmptyTextComponent implements Image {
 
             String tmp = null;
 
-            if (!legacyMode) {
+            if (!isLegacyConfig()) {
                 if (asset != null && StringUtils.isNotBlank(renditionName)) {
                     final AssetRenditionParameters parameters =
                             new AssetRenditionParameters(asset, renditionName, false);
@@ -150,6 +150,16 @@ public class ImageImpl extends AbstractEmptyTextComponent implements Image {
         }
 
         return src;
+    }
+    
+    private boolean isLegacyConfig() {
+    	if(legacyMode) {
+    		return true;
+    	} else if(StringUtils.isBlank(renditionName) && StringUtils.isNotBlank(computedProperty)){
+    		return true;
+    	}
+    	
+    	return false;
     }
 
     @Override

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/VideoImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/VideoImpl.java
@@ -92,7 +92,7 @@ public class VideoImpl extends AbstractEmptyTextComponent implements Video {
         if (src == null) {
             String tmp = null;
 
-            if (!legacyMode) {
+            if (!isLegacyConfig()) {
                 if (asset != null && StringUtils.isNotBlank(renditionName)) {
                     final AssetRenditionParameters parameters =
                             new AssetRenditionParameters(asset, renditionName, false);
@@ -117,6 +117,16 @@ public class VideoImpl extends AbstractEmptyTextComponent implements Video {
         }
 
         return src;
+    }
+    
+    private boolean isLegacyConfig() {
+    	if(legacyMode) {
+    		return true;
+    	} else if(StringUtils.isBlank(renditionName) && StringUtils.isNotBlank(computedProperty)){
+    		return true;
+    	}
+    	
+    	return false;
     }
 
     /**


### PR DESCRIPTION
relates to the comments I left in the PR. Basically the corner case trying to solve is that until a user opens the dialog for the Image / video component the legacyMode string won't exist...thus the component thinks it has not been configured correctly and won't pull the legacySrc